### PR TITLE
Add ember-try to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,8 @@
 bower.json
 ember-cli-build.js
 testem.js
+
+# ember-try
+.node_modules.ember-try/
+bower.json.ember-try
+package.json.ember-try


### PR DESCRIPTION
Otherwise, all of the deployer's local `.node_modules.ember-try/` modules get bundled into the package, which results in `0.4.0` being ~150MB.